### PR TITLE
fix(camoufoxnative): normalize non-standard SameSite cookie attributes during login

### DIFF
--- a/internal/camoufoxnative/login.go
+++ b/internal/camoufoxnative/login.go
@@ -324,8 +324,11 @@ func decodeStorageCookie(value map[string]any) (storageCookie, bool) {
 		}
 	}
 	sameSite, _ := value["sameSite"].(string)
-	if sameSite != "" {
-		sameSite = strings.ToUpper(sameSite[:1]) + strings.ToLower(sameSite[1:])
+	sameSite = strings.ToLower(strings.TrimSpace(sameSite))
+	if sameSite != "none" && sameSite != "lax" && sameSite != "strict" {
+		sameSite = ""
+	} else {
+		sameSite = strings.ToUpper(sameSite[:1]) + sameSite[1:]
 	}
 	partitionKey, _ := value["partitionKey"].(string)
 	httpOnly, _ := value["httpOnly"].(bool)


### PR DESCRIPTION
### 🎯 Problem
When adding or logging into an account via isolated Camoufox browser (`LoginAccount` / `CreateAccount`), the operation fails during storage state validation with the following error:
> `账户添加失败 | 耗时=21.734s | 错误=storage state Cookie _ga 的 SameSite 无效 source=auth`

This occurs because WebDriver BiDi (`storage.getCookies`) returns non-standard `SameSite` policy values for certain browser cookies (such as `"default"` or `"unspecified"` for analytics cookies like `_ga`). `decodeStorageCookie` blindly title-cased any non-empty string (`"default"` $\rightarrow$ `"Default"`), which subsequently failed strict Playwright `SameSite` schema validation in `StorageState.Validate()`, expecting only `""`, `"Lax"`, `"Strict"`, or `"None"`.

---

### 🛠️ Changes
- **`internal/camoufoxnative/login.go`**:
  - Normalized incoming `sameSite` strings from BiDi to lowercase.
  - Filtered values so only standard `"lax"`, `"strict"`, and `"none"` are capitalized into valid Playwright `SameSite` values (`"Lax"`, `"Strict"`, `"None"`).
  - Mapped any other values (including `"default"`, `"unspecified"`, or empty strings) to `""`, aligning with the existing behavior in `internal/chromeauth/auth.go`.

---

### ✅ Verification / Testing
- [x] Successfully added a new account through the isolated Camoufox login UI without `SameSite` validation errors.
- [x] Verified exported `storage-state.json` contains valid `SameSite` values conforming to `StorageState.Validate()`.
- [x] Tested account verification (`VerifyAccount`) and subsequent service launch transitions to `RUNNING`.